### PR TITLE
fix libxmlmm.so not found

### DIFF
--- a/ichthus_driver/CMakeLists.txt
+++ b/ichthus_driver/CMakeLists.txt
@@ -69,6 +69,12 @@ install(TARGETS
   mcm_management_node
   DESTINATION lib/${PROJECT_NAME})
 
+install(FILES
+  ${LIB_XMLMM}
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+
 install(DIRECTORY
   cfg
   DESTINATION share/${PROJECT_NAME}


### PR DESCRIPTION
Install the libxmlmm.so in install.
then, kia_reader_node links the proper library path

